### PR TITLE
refactor: rng control consolidation

### DIFF
--- a/configs/mnist/mnist_classification_example.yaml
+++ b/configs/mnist/mnist_classification_example.yaml
@@ -12,3 +12,5 @@ solvers:
 sample-sizes:
   - 100
   - 250
+
+rng-seed: 42


### PR DESCRIPTION
Created to standardize control over rng elements via config for all types of experiments. Changes to color transfer rng were kept at refactor/color_transfer_mnist, as they depend on previous commits there, but they share the same approach.